### PR TITLE
Allow sorting reviews by updated date

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ detox
 
 usage: review-rot [-h] [-c CONFIG] [-s {older,newer}] [-v VALUE]
                   [-d {y,m,d,h,min}] [-f {oneline,indented,json}]
-                  [--show-last-comment [DAYS]] [--reverse] [--comment-sort]
-                  [--debug] [--email EMAIL [EMAIL ...]]
-                  [--irc CHANNEL [CHANNEL ...]] [-k] [--cacert CACERT]
+                  [--show-last-comment [DAYS]] [--reverse]
+                  [--sort {submitted, updated, commented}] [--debug]
+                  [--email EMAIL [EMAIL ...]] [--irc CHANNEL [CHANNEL ...]]
+                  [-k] [--cacert CACERT]
 
 Lists pull/merge/change requests for github, gitlab, pagure and gerrit
 
@@ -58,7 +59,9 @@ optional arguments:
                         in which last comments are newer than specified number
                         of days
   --reverse             Display results with the most recent first
-  --comment-sort        Display results sorted by last comment
+  --sort {submitted,updated,commented}
+                        Display results sorted by the chosen event time.
+                        Defaults to submitted
   --debug               Display debug logs on console
   --email EMAIL [EMAIL ...]
                         send output to list of email adresses

--- a/bin/review-rot
+++ b/bin/review-rot
@@ -117,8 +117,8 @@ def main(cli_args, valid_choices):
         }
         sort_attr = sort_index.get(sort_by)
 
-        # As sort_index has to be explicitly match, ensure that is kept in sync
-        # with sort choices list.
+        # As sort_index has to be explicitly matched, ensure that is kept in
+        # sync with sort choices list.
         if sort_attr is None:
             error_message = 'Sort by {} not supported'.format(sort_by)
             log.debug(error_message)

--- a/bin/review-rot
+++ b/bin/review-rot
@@ -98,11 +98,33 @@ def main(cli_args, valid_choices):
                     )
                 )
 
-    # Now, with all results in place, sort them and print
+    # With the --sort argument, --comment-sort is kept for backwards
+    # compatibility. Equivalent to --sort commented
     if arguments.get('comment_sort'):
+        arguments['sort'] = 'commented'
+
+    # Now, with all results in place, sort them and print
+    # If sort is not passed or not provided as configuration argument, use the
+    # first element of the sort choices list as default.
+    sort_by = arguments.get('sort', choices['sort'][0])
+
+    if sort_by == 'commented':
         sorting_key = sort_by_last_comment
     else:
-        sorting_key = operator.attrgetter('time')
+        sort_index = {
+            'submitted': 'time',
+            'updated': 'updated_time',
+        }
+        sort_attr = sort_index.get(sort_by)
+
+        # As sort_index has to be explicitly match, ensure that is kept in sync
+        # with sort choices list.
+        if sort_attr is None:
+            error_message = 'Sort by {} not supported'.format(sort_by)
+            log.debug(error_message)
+            raise ValueError(error_message)
+
+        sorting_key = operator.attrgetter(sort_attr)
 
     sorted_results = sorted(
         results,
@@ -240,8 +262,12 @@ if __name__ == '__main__':
     state_choices = ['older', 'newer']
     format_choices = ['oneline', 'indented', 'json']
 
-    choices = {'duration': duration_choices, 'state': state_choices,
-               'format': format_choices}
+    choices = {
+        'duration': duration_choices,
+        'state': state_choices,
+        'format': format_choices,
+        'sort': ['submitted', 'updated', 'commented'],
+    }
 
     parser = argparse.ArgumentParser(
         description='Lists pull/merge/change requests for github, gitlab,'
@@ -281,8 +307,18 @@ if __name__ == '__main__':
                              'specified number of days')
     parser.add_argument('--reverse', action='store_true',
                         help='Display results with the most recent first')
+    # With --sort argument added,  --comment-sort is kept for backwards
+    # compatibility. Use --sort commented instead.
     parser.add_argument('--comment-sort', action='store_true',
-                        help='Display results sorted by last comment')
+                        help=argparse.SUPPRESS)
+    # Default value is left as None to ensure that the argument passed here
+    # takes precedence over the value in configuration arguments.
+    parser.add_argument('--sort',
+                        default=None,
+                        choices=choices['sort'],
+                        help=('Display results sorted by the chosen event '
+                              'time. Defaults to '
+                              '{}').format(choices['sort'][0]))
     parser.add_argument('--debug', action='store_true',
                         help='Display debug logs on console')
     parser.add_argument('--email', nargs="+",

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -172,12 +172,13 @@ class BaseService(object):
 
 class BaseReview(object):
     def __init__(self, user=None, title=None, url=None,
-                 time=None, comments=None, image=None,
+                 time=None, updated_time=None, comments=None, image=None,
                  last_comment=None, project_name=None, project_url=None):
         self.user = user
         self.title = title
         self.url = url
         self.time = time
+        self.updated_time = updated_time
         self.comments = comments
         self.image = image
         self.last_comment = last_comment
@@ -358,6 +359,7 @@ class BaseReview(object):
             'url': self.url,
             'relative_time': self.since,
             'time': time.mktime(self.time.timetuple()),
+            'updated_time': time.mktime(self.updated_time.timetuple()),
             'comments': self.comments,
             'type': type(self).__name__,
             'image': self.image,

--- a/reviewrot/gerritstack.py
+++ b/reviewrot/gerritstack.py
@@ -164,8 +164,11 @@ class GerritService(BaseService):
         res_ = []
         for decoded_response in decoded_responses:
 
+            time_format = "%Y-%m-%d %H:%M:%S.%f"
             created_date = datetime.strptime(decoded_response['created'][:-3],
-                                             "%Y-%m-%d %H:%M:%S.%f")
+                                             time_format)
+            updated_date = datetime.strptime(decoded_response['updated'][:-3],
+                                             time_format)
             result = self.check_request_state(created_date, state_, value,
                                               duration)
 
@@ -195,6 +198,7 @@ class GerritService(BaseService):
                                url="{}/{}".format(self.url,
                                                   str(change_number)),
                                time=created_date,
+                               updated_time=updated_date,
                                comments=self.get_comments_count(
                                    comments_response),
                                last_comment=last_comment,

--- a/reviewrot/githubstack.py
+++ b/reviewrot/githubstack.py
@@ -150,6 +150,7 @@ class GithubService(BaseService):
                                title=pr.title,
                                url=pr.html_url,
                                time=pr.created_at,
+                               updated_time=pr.updated_at,
                                comments=pr.review_comments+pr.comments,
                                image=pr.user.avatar_url,
                                last_comment=last_comment,

--- a/reviewrot/gitlabstack.py
+++ b/reviewrot/gitlabstack.py
@@ -153,10 +153,14 @@ class GitlabService(BaseService):
             try:
                 mr_date = datetime.datetime.strptime(
                     mr.created_at, '%Y-%m-%dT%H:%M:%S.%fZ')
+                mr_updated_date = datetime.datetime.strptime(
+                    mr.updated_at, '%Y-%m-%dT%H:%M:%S.%fZ')
 
             except ValueError:
                 mr_date = datetime.datetime.strptime(
                     mr.created_at, '%Y-%m-%dT%H:%M:%SZ')
+                mr_updated_date = datetime.datetime.strptime(
+                    mr.updated_at, '%Y-%m-%dT%H:%M:%SZ')
 
             """ check if review request is older/newer than specified time
             interval"""
@@ -179,6 +183,7 @@ class GitlabService(BaseService):
                                title=mr.title,
                                url=mr.web_url,
                                time=mr_date,
+                               updated_time=mr_updated_date,
                                comments=mr.user_notes_count,
                                # XXX - I don't know how to find gitlab avatars
                                # for now.  Can we figure this out later?

--- a/reviewrot/pagurestack.py
+++ b/reviewrot/pagurestack.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import hashlib
 import logging
 from six.moves import urllib
@@ -91,15 +91,19 @@ class PagureService(BaseService):
                 repo_reference, res['id']
             )
             # fetch the date pull request was filed at
-            created_date = datetime.datetime.utcfromtimestamp(
+            created_date = datetime.utcfromtimestamp(
                 int(res['date_created'])).strftime('%Y-%m-%d %H:%M:%S')
+            updated_date = datetime.utcfromtimestamp(
+                int(res['last_updated'])).strftime('%Y-%m-%d %H:%M:%S')
             # format the date pull request was filed at
             try:
-                date = datetime.datetime.strptime(created_date,
-                                                  '%Y-%m-%d %H:%M:%S.%f')
+                date = datetime.strptime(created_date, '%Y-%m-%d %H:%M:%S.%f')
+                updated_time = datetime.strptime(updated_date,
+                                                 '%Y-%m-%d %H:%M:%S.%f')
             except ValueError:
-                date = datetime.datetime.strptime(created_date,
-                                                  '%Y-%m-%d %H:%M:%S')
+                date = datetime.strptime(created_date, '%Y-%m-%d %H:%M:%S')
+                updated_time = datetime.strptime(updated_date, '%Y-%m-%d %H:%M:%S')
+
             """ check if review request is older/newer than specified time
             interval"""
             result = self.check_request_state(date,
@@ -122,6 +126,7 @@ class PagureService(BaseService):
                                title=res['title'],
                                url=url,
                                time=date,
+                               updated_time=updated_time,
                                comments=len(res['comments']),
                                image=self._avatar(res['user']['name'], ssl_verify=ssl_verify),
                                last_comment=last_comment,
@@ -148,7 +153,7 @@ class PagureService(BaseService):
         comments = res['comments']
 
         if comments:
-            last_comment_date = datetime.datetime.utcfromtimestamp(
+            last_comment_date = datetime.utcfromtimestamp(
                 int(comments[-1]['date_created']))
             return LastComment(
                 author=str(comments[-1]['user']['name']),

--- a/test/test.py
+++ b/test/test.py
@@ -498,6 +498,7 @@ class CommandLineParserTest(TestCase):
             duration=None,
             state=None,
             value=None,
+            sort=None,
         )
 
         config = self.config["test1"]
@@ -516,6 +517,7 @@ class CommandLineParserTest(TestCase):
             and arguments.get("duration") is None
             and arguments.get("value") is None
         )
+        sort_result = arguments.get("sort") == config_args.get("sort")
 
         self.assertTrue(
             debug_result
@@ -523,6 +525,7 @@ class CommandLineParserTest(TestCase):
             and format_result
             and ssl_result
             and group_arguments
+            and sort_result
         )
 
     def test_args_from_command_line(self):
@@ -535,6 +538,7 @@ class CommandLineParserTest(TestCase):
             duration=None,
             state=None,
             value=None,
+            sort='updated',
         )
 
         config = self.config["test2"]
@@ -554,6 +558,7 @@ class CommandLineParserTest(TestCase):
             and arguments.get("duration") is None
             and arguments.get("value") is None
         )
+        sort_result = arguments.get("sort") == vars(cli_args).get('sort')
 
         self.assertTrue(
             debug_result
@@ -561,6 +566,7 @@ class CommandLineParserTest(TestCase):
             and format_result
             and ssl_result
             and group_arguments
+            and sort_result
         )
 
     def test_args_from_command_line_except_format(self):
@@ -573,6 +579,7 @@ class CommandLineParserTest(TestCase):
             duration=None,
             state=None,
             value=None,
+            sort=None,
         )
 
         config = self.config["test3"]
@@ -592,6 +599,7 @@ class CommandLineParserTest(TestCase):
             and arguments.get("duration") is None
             and arguments.get("value") is None
         )
+        sort_result = arguments.get('sort') is None
 
         self.assertTrue(
             debug_result

--- a/test/test_command_line.yaml
+++ b/test/test_command_line.yaml
@@ -4,6 +4,7 @@ test1:
     insecure: True
     reverse: True
     debug: True
+    sort: commented
 
 test2:
   arguments:

--- a/web/index.html
+++ b/web/index.html
@@ -43,7 +43,8 @@
 			</div>
 			<div class="media-body">
 				<a href="{{url}}" target="_blank"><h4 class="media-heading">{{title}}</h4></a>
-				submitted {{relative_time}} ago by <b>@{{user}}</b>, with {{comments}} comments.<br />
+				Submitted {{relative_time}} ago by <b>@{{user}}</b>, with {{comments}} comments.<br />
+				{{#if relative_updated_time}}Updated {{relative_updated_time}}<br />{{/if}}
 				<a href="{{ repo_url }}" target="_blank" class="label label-default">{{pretty_repo}}</a>
 			</div>
 		</div>

--- a/web/js/site.js
+++ b/web/js/site.js
@@ -30,7 +30,10 @@ $(document).ready(function() {
 			$.each(data, function(key, value) {
 				value.pretty_repo = prettify_repo(value.url);
 				// Strip off the pull request from the URL to get the base URL of the repo
-				value.repo_url = value.url.split('/').slice(0, -2).join('/')
+				value.repo_url = value.url.split('/').slice(0, -2).join('/');
+				if (value.updated_time) {
+					value.relative_updated_time = moment.unix(value.updated_time).fromNow();
+				}
 				if (value.title.toUpperCase().indexOf("WIP") == -1) {
 					$('#reviews').append(entry_template(value));
 				} else {


### PR DESCRIPTION
Sorting reviews by last comment time instead of submitted time allows to keep
track of active and stale reviews. But there are other events that can make
the review count as active, for example, a new patch set in Gerrit.

The updated time property is available in the response from all the review
services, so let's add it to review-rot and allow sorting the reviews
using this value to give a better picture of stale and active reviews.

The --sort argument is added, supporting sort by submitted time, updated
time and last commented.

Sorting by last comment time was already available using the
--sort-comment argument. With the new sort argument, --sort commented is
equivalent, so the former argument is hidden from the help output and
kept for backwards compatibility.

The updated time property is added to the JSON output format, and the
web interface is updated to include this value using the moment
javascript library to show it in relative time.

Test for arguments are updated with the sort option.