### PR TITLE
Replace -s -d -n with --age argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ### New: 
 - Phabricator support (check examples/sampleinput_phabricator.yaml )
 - Possibility of omitting WIP pull requests/merge requests in output with *--ignore-wip* argument
+- Replace *-s, -v, -d* arguments with one argument *--age*
 
 # review-rot
 reviewrot is a CLI tool, that helps to list down open review requests from github, gitlab, pagure, gerrit and phabricator.
@@ -36,10 +37,10 @@ detox
 ```shell
 > review-rot --help
 
-usage: review-rot [-h] [-c CONFIG] [-s {older,newer}] [-v VALUE]
-                  [-d {y,m,d,h,min}] [-f {oneline,indented,json}]
-                  [--show-last-comment [DAYS]] [--reverse]
-                  [--sort {submitted, updated, commented}] [--debug]
+usage: review-rot [-h] [-c CONFIG]
+                  [--age {older,newer} [#y #m #d #h #min ...]]
+                  [-f {oneline,indented,json}] [--show-last-comment [DAYS]]
+                  [--reverse] [--sort {submitted,updated,commented}] [--debug]
                   [--email EMAIL [EMAIL ...]] [--irc CHANNEL [CHANNEL ...]]
                   [--ignore-wip] [-k] [--cacert CACERT]
 
@@ -49,13 +50,8 @@ optional arguments:
   -h, --help            show this help message and exit
   -c CONFIG, --config CONFIG
                         Configuration file to use
-  -s {older,newer}, --state {older,newer}
-                        Pull requests state 'older' or 'newer'
-  -v VALUE, --value VALUE
-                        Pull requests duration in terms of value(int)
-  -d {y,m,d,h,min}, --duration {y,m,d,h,min}
-                        Pull requests duration in terms of y=years,m=months,
-                        d=days, h=hours, min=minutes
+  --age {older,newer} [#y #m #d #h #min ...]
+                        Filter pull request based on their relative age
   -f {oneline,indented,json}, --format {oneline,indented,json}
                         Choose from one of a few different styles
   --show-last-comment [DAYS]
@@ -78,7 +74,18 @@ SSL:
   --cacert CACERT       Path to CA certificate to use for SSL certificate
                         verification
 
+
 ```
+
+You can filter MRs/PRs based on their relative age
+```
+review-rot --age older 5d 10h
+```
+outputs MRs/PRs which were submitted more than 5 days and 10 hours ago
+```
+review-rot --age newer 5d 10h
+```
+outputs MRs/PRs which submitted in the last 5 days and 10 hours
 
 You can use **--show-last-comment** flag to include the text of last comment with formats:
 - json

--- a/bin/review-rot
+++ b/bin/review-rot
@@ -93,9 +93,7 @@ def main():
                         git_service.request_reviews(
                             user_name=res.get('user_name'),
                             repo_name=res.get('repo_name'),
-                            state_=arguments.get('state'),
-                            value=arguments.get('value'),
-                            duration=arguments.get('duration'),
+                            age=arguments.get('age'),
                             show_last_comment=arguments.get('show_last_comment'),
                             token=token,
                             host=remove_trailing_slash_from_url(item.get('host')),
@@ -109,9 +107,7 @@ def main():
                 results.extend(
                     git_service.request_reviews(
                         user_names=item['repos'],
-                        state_=arguments.get('state'),
-                        value=arguments.get('value'),
-                        duration=arguments.get('duration'),
+                        age=arguments.get('age'),
                         show_last_comment=arguments.get('show_last_comment'),
                         token=item.get('token'),
                         host=remove_trailing_slash_from_url(item.get('host')),

--- a/examples/sampleinput_new_format.yaml
+++ b/examples/sampleinput_new_format.yaml
@@ -36,3 +36,4 @@ arguments:
   duration: d
   cacert: ~/cacert_location
   ignore_wip: true
+  age: "older 5d 4h"

--- a/reviewrot/githubstack.py
+++ b/reviewrot/githubstack.py
@@ -11,8 +11,7 @@ class GithubService(BaseService):
     This class represents Github. The reference can be found here:
     https://developer.github.com/v3/
     """
-    def request_reviews(self, user_name, repo_name=None, state_=None,
-                        value=None, duration=None,
+    def request_reviews(self, user_name, repo_name=None, age=None,
                         show_last_comment=None, token=None, host=None,
                         **kwargs):
         """
@@ -25,12 +24,8 @@ class GithubService(BaseService):
             user_name (str): Github username or organization name
             repo_name (str): Github repository name for specified
                              username or organization
-            state_ (str): The filter state for pull requests, e.g, older
-                          or newer
-            value (int): The value in terms of duration for requests
-                         to be older or newer than
-            duration (str): The duration in terms of period(year, month, hour,
-                            minute) for requests to be older or newer than
+            age (Age): Contains the filter state for pull requests,
+                       e.g, older or newer and date
             show_last_comment (int): Show text of last comment and
                                      filter out pull requests in which
                                      last comments are newer than
@@ -57,8 +52,7 @@ class GithubService(BaseService):
         if repo_name is not None:
             # get pull requests for specified username and repo name
             res = self.get_reviews(uname=uname, repo_name=repo_name,
-                                   state_=state_, value=value,
-                                   duration=duration,
+                                   age=age,
                                    show_last_comment=show_last_comment)
             # extend incase of a non empty result
             if res:
@@ -74,16 +68,14 @@ class GithubService(BaseService):
             """
             for repo in repo_list:
                 res = self.get_reviews(uname=uname, repo_name=repo.name,
-                                       state_=state_, value=value,
-                                       duration=duration,
+                                       age=age,
                                        show_last_comment=show_last_comment)
                 # extend incase of a non empty result
                 if res:
                     response.extend(res)
         return response
 
-    def get_reviews(self, uname, repo_name, state_=None,
-                    value=None, duration=None, show_last_comment=None):
+    def get_reviews(self, uname, repo_name, age=None, show_last_comment=None):
         """
         Fetches pull requests for specified username and repo name.
         Formats the pull requests details and print it on console.
@@ -92,13 +84,8 @@ class GithubService(BaseService):
             user_name (str): Github username or organization name
             repo_name (str): Github repository name for specified
                              username or organization
-            state_ (str): The filter(state) for pull requests, e.g, older
-                        or newer
-            value (int): The value in terms of duration for requests
-                         to be older or newer than
-            duration (str): The duration in terms of period(year,
-                            month, hour, minute) for requests to be
-                            older or newer than
+            age (Age): Contains the filter state for pull requests,
+                       e.g, older or newer and date
             show_last_comment (int): Show text of last comment and
                                      filter out pull requests in which
                                      last comments are newer than
@@ -129,13 +116,12 @@ class GithubService(BaseService):
 
             """ check if review request is older/newer than specified time
             interval"""
-            result = self.check_request_state(pr.created_at,
-                                              state_, value, duration)
+            result = self.check_request_state(pr.created_at, age)
 
             if result is False:
                 # skip the current pull request
                 log.debug("review request '%s' is not %s than specified"
-                          " time interval", pr.title, state_)
+                          " time interval", pr.title, age.state)
                 continue
 
             if last_comment and show_last_comment:

--- a/reviewrot/gitlabstack.py
+++ b/reviewrot/gitlabstack.py
@@ -14,8 +14,7 @@ class GitlabService(BaseService):
     This class represents Gitlab. The reference can be found here:
      https://docs.gitlab.com/ee/api/
     """
-    def request_reviews(self, user_name, repo_name=None, state_=None,
-                        value=None, duration=None,
+    def request_reviews(self, user_name, repo_name=None, age=None,
                         show_last_comment=None, token=None, host=None,
                         ssl_verify=True, **kwargs):
         """
@@ -28,13 +27,8 @@ class GitlabService(BaseService):
             user_name (str): Gitlab namespace
             repo_name (str): Gitlab project name for specified
                           namespace
-            state_ (str): The state for pull requests, e.g, older
-                        or newer
-            value (int): The value in terms of duration for requests
-                         to be older or newer than
-            duration (str): The duration in terms of period(year, month,
-                            hour, minute) for requests to be older or
-                            newer than
+            age (Age): Contains the filter state for pull requests,
+                       e.g, older or newer and date
             show_last_comment (int): Show text of last comment and
                                      filter out pull requests in which
                                      last comments are newer than
@@ -69,8 +63,7 @@ class GitlabService(BaseService):
                                 % (repo_name, user_name))
             # get merge requests for specified username and project name
             res = self.get_reviews(uname=user_name, project=project,
-                                   state_=state_, value=value,
-                                   duration=duration,
+                                   age=age,
                                    show_last_comment=show_last_comment)
             # extend in case of a non empty result
             if res:
@@ -95,32 +88,25 @@ class GitlabService(BaseService):
 
                 project = gl.projects.get(group_project.id)
                 res = self.get_reviews(uname=user_name, project=project,
-                                       state_=state_, value=value,
-                                       duration=duration)
+                                       age=age)
 
                 # extend in case of a non empty result
                 if res:
                     response.extend(res)
         return response
 
-    def get_reviews(self, uname, project, state_=None,
-                    value=None, duration=None, show_last_comment=None):
+    def get_reviews(self, uname, project, age=None, show_last_comment=None):
         """
         Fetches merge requests for specified username(groupname)
         and repo(project) name.
         Formats the merge requests details and print it on console.
 
         Args:
-            user_name (str): Gitlab namespace
-            repo_name (str): Gitlab project name for specified
-                             namespace
-            state_ (str): The state for pull requests, e.g, older
-                        or newer
-            value (str): The value in terms of duration for requests
-                         to be older or newer than
-            duration (str): The duration in terms of period(year, month,
-                            hour, minute) for requests to be older or
-                            newer than.
+            uname (str): Gitlab namespace
+            project (str): Gitlab project name for specified
+                           namespace
+            age (Age): Contains the filter state for pull requests,
+                       e.g, older or newer and date
             show_last_comment (int): Show text of last comment and
                                      filter out pull requests in which
                                      last comments are newer than
@@ -164,11 +150,11 @@ class GitlabService(BaseService):
 
             """ check if review request is older/newer than specified time
             interval"""
-            result = self.check_request_state(mr_date, state_, value, duration)
+            result = self.check_request_state(mr_date, age)
 
             if result is False:
                 log.debug("merge request '%s' is not %s than specified"
-                          " time interval", mr.title, state_)
+                          " time interval", mr.title, age.state)
                 continue
 
             if last_comment and show_last_comment:

--- a/reviewrot/pagurestack.py
+++ b/reviewrot/pagurestack.py
@@ -17,8 +17,7 @@ class PagureService(BaseService):
         self.instance = "https://pagure.io"
         self.header = None
 
-    def request_reviews(self, user_name, repo_name=None, state_=None,
-                        value=None, duration=None,
+    def request_reviews(self, user_name, repo_name=None, age=None,
                         show_last_comment=None, host=None, token=None,
                         ssl_verify=True, **kwargs):
         """
@@ -30,13 +29,8 @@ class PagureService(BaseService):
             user_name (str): Pagure username or organization name
             repo_name (str): Pagure repository name for specified
                              username or organization
-            state_ (str): The filter(state) for pull requests, e.g, older
-                          or newer
-            value (int): The value in terms of duration for requests
-                         to be older or newer than
-            duration (str): The duration in terms of period(year, month,
-                            hour, minute) for requests to be older or
-                            newer than
+            age (Age): Contains the filter state for pull requests,
+                       e.g, older or newer and date
             show_last_comment (int): Show text of last comment and
                                      filter out pull requests in which
                                      last comments are newer than
@@ -106,11 +100,10 @@ class PagureService(BaseService):
 
             """ check if review request is older/newer than specified time
             interval"""
-            result = self.check_request_state(date,
-                                              state_, value, duration)
+            result = self.check_request_state(date, age)
             if result is False:
                 log.debug("pull request '%s' is not %s than specified"
-                          " time interval", res['title'], state_)
+                          " time interval", res['title'], age.state)
                 continue
 
             if last_comment and show_last_comment:

--- a/test/test_command_line.yaml
+++ b/test/test_command_line.yaml
@@ -21,31 +21,14 @@ test3:
 
 test4:
   arguments:
-    state: newer
-    duration: m
-
-test5:
-  arguments:
-    state: newer
-    duration: d
-    value: 4
-
-test6:
-  arguments:
-    state: newer
-    duration: d
-    value: 4
-
-test7:
-  arguments:
     insecure: False
     cacert: ~/review-rot/
 
-test8:
+test5:
   arguments:
     cacert: ~/
 
-test9:
+test6:
   arguments:
     insecure: True
     cacert: ~/

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -40,9 +40,7 @@ def mock_get_repos():
 def mock_github_get_reviews(
     uname,
     repo_name,
-    state_=None,
-    value=None,
-    duration=None,
+    age=None,
     show_last_comment=None,
 ):
     msg = [github_config["msg"]]
@@ -113,9 +111,7 @@ def mock_groups_search(user_name):
 def mock_gitlab_get_reviews(
     uname,
     project,
-    state_=None,
-    value=None,
-    duration=None,
+    age=None,
     show_last_comment=None,
 ):
     msg = [gitlab_config["msg"]]
@@ -222,8 +218,7 @@ def mock_phabricator_get_comments_(id, phab):
         ]
 
 
-def mock_phabricator_get_reviews(phab, reviews, host, state_,
-                                 value, duration, show_last_comment,
+def mock_phabricator_get_reviews(phab, reviews, host, age, show_last_comment,
                                  raw_response):
     res = []
     date_created = datetime.datetime.strptime('16Sep2012', '%d%b%Y')


### PR DESCRIPTION
Fixes https://github.com/redhat-aqe/review-rot/issues/67, But instead of using --since and --until we decided to use --age.

`review-rot --age older 5d 10h `
outputs MRs/PRs which ale older than 5 days and 10 hours,
`review-rot --age newer 5d 10h `
outputs MRs/PRs which are newer than 5 days and 10 hours.