### PR TITLE
Fix JSON formatting.

### DIFF
--- a/bin/review-rot
+++ b/bin/review-rot
@@ -170,8 +170,9 @@ def main(cli_args, valid_choices):
             '\x02{0} Code Review Reminder {0}\x02'.format('*' * 45)
         )
         # output maximum 20 merge requests
-        for result in sorted_results[:20]:
-            irc_bot.send_msg(result.format(style="irc"))
+        N = 20
+        for i, result in enumerate(sorted_results[:N]):
+            irc_bot.send_msg(result.format(style="irc", i=i, N=N))
 
         if len(sorted_results) > 20:
             irc_bot.send_msg(

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -318,13 +318,8 @@ class BaseReview(object):
             formatted_string(str): Formatted string as per style
         """
         # Include a comma after every entry, except the last.
-        if i and N:
-            suffix = ',' if i < N - 1 else ''
-
-            return json.dumps(self.__json__(show_last_comment), indent=2) + suffix
-        # If we omit the return statement, this function will return None
-        # which will cause a malformed json.
-        return ''
+        suffix = ',' if i < N - 1 else ''
+        return json.dumps(self.__json__(show_last_comment), indent=2) + suffix
 
     def _format_irc(self):
         """

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -230,7 +230,7 @@ class BaseReview(object):
     def since(self):
         return self.format_duration(created_at=self.time)
 
-    def format(self, style, i=None, N=None, show_last_comment=None):
+    def format(self, style, i, N, show_last_comment=None):
         """
         Format the result in a given style.
         Args:


### PR DESCRIPTION
The way the code previously worked here, if either `i` or `N` were zero, then
we would not render any JSON for the element.

This always occurred on the *first* item in the list, for which `i` is always
zero.  This means our JSON-based reports have been missing their first hidden
entry, since 7fe84e8979.