### PR TITLE
Add Phabricator support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+### New: Phabricator support (check examples/sampleinput_phabricator.yaml )
+
 # review-rot
-reviewrot is a CLI tool, that helps to list down open review requests from github, gitlab, pagure and gerrit.
+reviewrot is a CLI tool, that helps to list down open review requests from github, gitlab, pagure, gerrit and phabricator.
 
 ## Sample I/P:
 Create '~/.reviewrot.yaml'. browse the [examples](https://github.com/nirzari/review-rot/tree/master/examples/) for content. 

--- a/bin/review-rot
+++ b/bin/review-rot
@@ -64,35 +64,52 @@ def main(cli_args, valid_choices):
         """
         if item['repos'] is not None:
             # for each input call specified git service
-            for data in item['repos']:
-                """
-                split and format username and repository name to further
-                request pull requests
-                """
-                res = format_user_repo_name(data, git_service)
-                """
-                get pull/merge/change requests for specified git service
-                """
-                token = item.get('token')
-                # Support pulling a token from an environment variable
-                # If the token value starts with "ENV.", then the value
-                # for the token will be pulled from the environment variable
-                # specified following "ENV."
-                # For example, if the token value specified in the config is
-                # "ENV.FOO", then the real value for the environment variable
-                # will be taken from the environment variable "FOO"
-                if token and token.startswith('ENV.'):
-                    token_env_var = token.split('ENV.')[1]
-                    token = os.environ.get(token_env_var)
+            if not (item['type'] == 'phabricator'):
+                for data in item['repos']:
+                    """
+                    split and format username and repository name to further
+                    request pull requests.
+                    """
+                    res = format_user_repo_name(data, git_service)
+                    """
+                    get pull/merge/change requests for specified git service
+                    """
+                    token = item.get('token')
+                    # Support pulling a token from an environment variable
+                    # If the token value starts with "ENV.", then the value
+                    # for the token will be pulled from the environment variable
+                    # specified following "ENV."
+                    # For example, if the token value specified in the config is
+                    # "ENV.FOO", then the real value for the environment variable
+                    # will be taken from the environment variable "FOO"
+                    if token and token.startswith('ENV.'):
+                        token_env_var = token.split('ENV.')[1]
+                        token = os.environ.get(token_env_var)
+                    results.extend(
+                        git_service.request_reviews(
+                            user_name=res.get('user_name'),
+                            repo_name=res.get('repo_name'),
+                            state_=arguments.get('state'),
+                            value=arguments.get('value'),
+                            duration=arguments.get('duration'),
+                            show_last_comment=arguments.get('show_last_comment'),
+                            token=token,
+                            host=remove_trailing_slash_from_url(item.get('host')),
+                            ssl_verify=arguments.get('ssl_verify'),
+                        )
+                    )
+            else:
+                # If we are parsing from phabricator, we do not need
+                # to loop through users, rather we can pass all
+                # users as a list
                 results.extend(
                     git_service.request_reviews(
-                        user_name=res.get('user_name'),
-                        repo_name=res.get('repo_name'),
+                        user_names=item['repos'],
                         state_=arguments.get('state'),
                         value=arguments.get('value'),
                         duration=arguments.get('duration'),
                         show_last_comment=arguments.get('show_last_comment'),
-                        token=token,
+                        token=item.get('token'),
                         host=remove_trailing_slash_from_url(item.get('host')),
                         ssl_verify=arguments.get('ssl_verify'),
                     )

--- a/examples/sampelinput_phabricator.yaml
+++ b/examples/sampelinput_phabricator.yaml
@@ -1,0 +1,7 @@
+- type: phabricator
+  token: my_phabricator_token
+  host: my_phabricator_host
+  repos:
+    - user_1
+    - user_2
+    - user_3

--- a/reviewrot/__init__.py
+++ b/reviewrot/__init__.py
@@ -10,6 +10,7 @@ from reviewrot.gerritstack import GerritService
 from reviewrot.githubstack import GithubService
 from reviewrot.gitlabstack import GitlabService
 from reviewrot.pagurestack import PagureService
+from reviewrot.phabricatorstack import PhabricatorService
 
 import yaml
 
@@ -34,6 +35,8 @@ def get_git_service(git):
         return PagureService()
     elif git == "gerrit":
         return GerritService()
+    elif git == "phabricator":
+        return PhabricatorService()
     else:
         raise ValueError('requested git service %s is not valid' % (git))
 

--- a/reviewrot/phabricatorstack.py
+++ b/reviewrot/phabricatorstack.py
@@ -1,0 +1,348 @@
+import logging
+from phabricator import Phabricator
+import datetime
+import re
+from reviewrot.basereview import BaseService, BaseReview, LastComment
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
+log = logging.getLogger(__name__)
+
+
+class PhabricatorService(BaseService):
+    """
+        This class represents Phabricator Service for Review Rot.
+    """
+    def request_reviews(self, host, token, user_names=None, state_=None,
+                        value=None, duration=None, show_last_comment=None,
+                        **kwargs):
+        """
+        Returns revision requests for specified username and repo name.
+        If user_names are not provided then requests pulls all open
+        revisions
+        Args:
+            host (str): The host Phabricator server url
+            token (str): Phabricator token for authentication
+                            (Looks like 'api-1234567890x')
+            user_names (lst(str)): Phabricator user names we want to query
+            state_ (str): The filter state for pull requests, e.g, older
+                          or newer
+            value (int): The value in terms of duration for requests
+                         to be older or newer than
+            duration (str): The duration in terms of period(year, month, hour,
+                            minute) for requests to be older or newer than
+            show_last_comment (int): Show text of last comment and
+                                     filter out pull requests in which
+                                     last comments are newer than
+                                     specified number of days
+        Returns:
+            response (list): Returns list of list of pull requests for
+                             specified username and reponame or all reponame
+                             for given username
+        Note:
+            We will use the list 'raw_response' to keep track of the
+            raw queries we make to phabricator. We do this to keep
+            API calls minimal, and first search through raw_response
+            before making another API call.
+        """
+        # Create Phabricator object with token
+        phab = Phabricator(host=urljoin(host, "/api/"), token=token)
+        phab.update_interfaces()
+        # Create response list
+        response = []
+        # Create raw response list to keep track of users we've come across
+        raw_response = []
+        if user_names:
+            # Find open reviews for all users (aka the list user_names)
+
+            # Generate a list of user phids based on their username
+            # Also begin keeping track of queried users in raw_response
+            user_phids, raw_response = self.generate_phids(user_names, phab)
+
+            # Query phabricator based on all users passed
+            reviews = self.differential_query(status='status-open',
+                                              responsibleUsers=user_phids,
+                                              phab=phab)
+        else:
+            # Find all open reviews
+            reviews = self.differential_query(status='status-open',
+                                              responsibleUsers=[], phab=phab)
+
+        # Format and go through all reviews for a user
+        res = self.get_reviews(phab=phab, reviews=reviews,
+                               raw_response=raw_response,
+                               host=host,
+                               state_=state_, value=value,
+                               duration=duration,
+                               show_last_comment=show_last_comment)
+        # extend in case of non-empty results
+        # If we've come across a revision that's dated < duration
+        # (i.e. too far in the past) we would have skipped it and
+        # returned nothing
+        if res:
+            response.extend(res)
+
+        return response
+
+    def get_reviews(self, phab, reviews, raw_response,
+                    host, state_=None,value=None,
+                    duration=None, show_last_comment=None):
+        """
+        Fetches pull requests for specified username and repo name.
+        Formats the pull requests details and print it on console.
+        Args:
+                phab (object): This is the Phabricator object to make API calls
+                reviews (dict): The list of open reviews that we are looking at
+                raw_response (lst(dict)): The raw data in the query, to use be used
+                                          later to minimize API calls
+                host (str): The host Phabricator server url
+                state_ (str): The filter(state) for pull requests, e.g, older
+                                or newer
+                value (int): The value in terms of duration for requests
+                                 to be older or newer than
+                duration (str): The duration in terms of period(year,
+                                    month, hour, minute) for requests to be
+                                    older or newer than
+                show_last_comment (int): Show text of last comment and
+                                             filter out pull requests in which
+                                             last comments are newer than
+                                             specified number of days
+        Returns:
+                response (list): Returns list of pull requests for specified
+                                 username and repo name
+        """
+
+        response = []
+        for review in reviews:
+            # Check if there is a last comment
+            comments = self.get_comments(id=review['id'], phab=phab)
+            last_comment = self.get_last_comment(comments=comments, phab=phab,
+                                                 raw_response=raw_response)
+
+            # Get and convert the date created and last modified to datetime
+
+            date_created = self.time_from_epoch(review['dateCreated'])
+            date_modified = self.time_from_epoch(review['dateModified'])
+
+            result = self.check_request_state(
+                date_created, state_, value, duration)
+
+            # Check if review should be looked at
+            if result is False:
+                # Skip the current review
+                log.debug("review request '%s' is not %s than specified"
+                          " time interval", review['title'], state_)
+                continue
+
+            if last_comment and show_last_comment:
+                # If our reviews last comment is newer than show_last_comment, skip
+                if self.has_new_comments(last_comment.created_at,
+                                         show_last_comment):
+                    log.debug("Pull request '%s' had "
+                              "new comments in last %s days",
+                              review['title'], show_last_comment)
+                    continue
+            # Query the author to get relevant information and
+            # update raw_response if needed
+            author_data, raw_response = self.author_data(
+                review['authorPHID'],
+                raw_response,
+                phab)
+
+            # Remove any fluff if the URL has it (i.e. www.google.com/api
+            # to www.google.com)
+            match = re.search(r'(.*)\/api', host)
+            host_cleaned = match.groups()[0] if match else host
+
+            # As the Phabricator does not work with project as much
+            # it was better to keep all project names as 'Phabricator'
+            # and link them back to the host URL.
+            res = PhabricatorReview(user=author_data['userName'],
+                                    title=review['title'],
+                                    url=review['uri'],
+                                    time=date_created,
+                                    updated_time=date_modified,
+                                    comments=len(comments),
+                                    image=author_data['image'],
+                                    last_comment=last_comment,
+                                    project_name="Phabricator",
+                                    project_url=host_cleaned)
+            log.debug(res)
+            response.append(res)
+        return response
+
+    def generate_phids(self, user_names, phab):
+        """
+        Helper function to generate the phids from the usernames passed into
+        the config file
+        Args:
+                user_names (lst(str)): The list of usernames
+                phab (object): This is the Phabricator object to make API calls
+        Returns:
+                list_of_phids (lst): A list of all phids associated with the users
+                raw_response (lst(dict)): The raw data in the query, to use be used
+                                          later to minimize API calls
+        """
+        list_of_phids = []
+        raw_response = []
+        query = (self.user_query_usernames(user_names, phab))
+        for user in query:
+            raw_response.append(user)
+            list_of_phids.append(user['phid'])
+        return list_of_phids, raw_response
+
+    def get_comments(self, id, phab):
+        """
+        Helper function to make API call to get all comments for a revision
+        Args:
+                id (str): The ID number for rhe revision
+                phab (object): This is the Phabricator object to make API calls
+                                (>=0.7.0)
+
+        Returns:
+                list_of_all_comments (lst): Returns an list representation of all comments
+        """
+        # Make API call to get a timeline of review (all events)
+        timeline = phab.differential.getrevisioncomments(ids=[int(id)])[id]
+        # Create a list to return
+        list_of_all_comments = []
+        for event in timeline:
+            if (event['action'] == 'comment'):
+                list_of_all_comments.append(event)
+        return list_of_all_comments
+
+    def get_last_comment(self, comments, phab, raw_response):
+        """
+        Helper function to get the last comment from a list of comments
+        Args:
+                comments (lst(str)): An list of comments
+                                        associated with a revision
+                phab (object): This is the Phabricator object to make API calls
+                                (>=0.7.0)
+                raw_response (lst(dict)): The raw response received from
+                                            individual user.query calls.
+                                            Keep updating and passing this
+                                            list as we call user.query
+        Returns:
+                LastComment (object): Returns the LastComment object
+                                      that can be used in ReviewRot
+        """
+        if len(comments) > 0:
+            # Get the username for the last comment
+            author, raw_response = self.author_data(author_phid=comments[0]['authorPHID'],
+                                                   phab=phab,
+                                                   raw_response=raw_response)
+            # Convert the timestamp to datetime
+            createdAt = self.time_from_epoch(comments[0]['dateCreated'])
+
+            # Return the last comment
+            return LastComment(author=author['userName'],
+                               body=comments[0]['content'],
+                               created_at=createdAt)
+
+    def author_data(self, author_phid, raw_response, phab):
+        """
+        Helper function to look up data related to authors (i.e. for last
+        comment or individual review). Keeps updating users seen in
+        raw_response
+        Args:
+                author_phid (str): The phid for the author queried
+                raw_response (lst(dict)): The raw response received from
+                                            individual user.query calls.
+                                            Keep updating and passing this
+                                            list as we call user.query
+                phab (object): This is the Phabricator object to make API calls
+                                (>=0.7.0)
+        Returns:
+                new_user/user (dict): The user that was queried
+                raw_response (lst(dict)): The updated (or same) list
+                                          that holds all the users
+                                          we've seen
+        """
+        for user in raw_response:
+            if user['phid'] == author_phid:
+                return user, raw_response
+
+        new_user = self.user_query_ids([author_phid], phab)[0]
+        raw_response.append(new_user)
+        return new_user, raw_response
+
+    def user_query_usernames(self, usernames, phab):
+        """
+        Helper function to query users based on usernames
+        Args:
+                usernames (lst(str)): The list of users to query for
+                phab (object): This is the Phabricator object to make API calls
+                               (>=0.7.0)
+
+        Returns:
+                return (dict): Returns the JSON response to phab.user.query(...)
+        Note:
+            This is a frozen method (i.e. will eventually
+            depreciate). The updated method (user.search)
+            does not return the users avatar URL (needed
+            for PhabricatorReview)
+        """
+        return phab.user.query(usernames=usernames)
+
+    def user_query_ids(self, phids, phab):
+        """
+        Helper function to query users based on phids
+        Args:
+                phids (lst(str)): The list of phids to query for
+                phab (object): This is the Phabricator object to make API calls
+                               (>=0.7.0)
+
+        Returns:
+                return (dict): Returns the JSON response to phab.user.query(...)
+        Note:
+            This is a frozen method (i.e. will eventually
+            depreciate). The updated method (user.search)
+            does not return the users avatar URL (needed
+            for PhabricatorReview)
+        """
+        return phab.user.query(phids=phids)
+
+    def differential_query(self, status, responsibleUsers, phab):
+        """
+        Helper function to query differentials
+        Args:
+                status (str): The list of open reviews
+                                that we are looking at
+                responsibleUsers (lst(str)): The filter(state)
+                                             for pull requests,
+                                             e.g, older or newer
+                phab (object): This is the Phabricator
+                               object to make API calls
+                                (>=0.7.0)
+
+        Returns:
+                return (dict): Returns the JSON response
+                             to phab.differential.query(...)
+        Note:
+            This is a frozen method (i.e. will eventually
+            depreciate). The updated method
+            (differential.revision.search) does not
+            support filtering based on status
+            (see trello note below)
+            https://trello.com/c/yDQZramE/504-do-not-use-phabricator-deprecated-methods
+        """
+        return phab.differential.query(status=status,
+                                       responsibleUsers=responsibleUsers)
+    def time_from_epoch(self, epoch):
+        """
+        Helper function to convert epoch time to datetime object
+        Args:
+                epoch (int): epoch time
+
+        Returns:
+                return (datetime.datetime): Returns datetime object representing
+                                            the epoch time.
+        """
+        return datetime.datetime.fromtimestamp(
+                float(epoch))
+
+class PhabricatorReview(BaseReview):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='review-rot',
           'python-gitlab>=1.6.0',
           'six',
           'Jinja2',
+          'phabricator>=0.7.0',
       ],
       tests_require=[
           'nose',

--- a/test/test.py
+++ b/test/test.py
@@ -1,8 +1,6 @@
 import logging
-
 import argparse
 import os
-
 import mock
 import yaml
 import test_mock
@@ -14,13 +12,162 @@ from reviewrot.githubstack import GithubService
 from reviewrot.gitlabstack import GitlabService
 from reviewrot.pagurestack import PagureService
 from reviewrot.gerritstack import GerritService
+from reviewrot.phabricatorstack import PhabricatorService
 from reviewrot import get_git_service, get_arguments, load_config_file
 from github.GithubException import BadCredentialsException
 from reviewrot.basereview import LastComment
 import datetime
+from phabricator import Phabricator
+
 
 # Disable logging to avoid messing up test output
 logging.disable(logging.CRITICAL)
+
+
+class PhabricatorTest(TestCase):
+    def setUp(self):
+        filename = join(dirname(__file__), "test_phabricatortest.yaml")
+        with open(filename, "r") as f:
+            self.config = yaml.safe_load(f)
+
+    def test_object_create(self):
+        self.assertTrue(isinstance((get_git_service("phabricator")),
+                                   PhabricatorService))
+
+    def test_request_review_token(self):
+        service = PhabricatorService()
+        with self.assertRaises(Exception) as context:
+            service.request_reviews(host=self.config["host"],
+                                    token=self.config["token"])
+        res = len(str(context.exception)) > 0
+        self.assertTrue(res)
+
+    @mock.patch('phabricator.Phabricator.update_interfaces',
+                side_effect=test_mock.mock_phabricator_update_interfaces)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.get_reviews',
+                side_effect=test_mock.mock_phabricator_get_reviews)
+    @mock.patch(
+        'reviewrot.phabricatorstack.PhabricatorService.differential_query',
+        side_effect=test_mock.mock_phabricator_differential_query)
+    def test_request_reviews_no_repo(
+            self,
+            mock_phabricator_update_interfaces,
+            mock_phabricator_get_reviews,
+            mock_phabricator_differential_query_no_repos):
+        response = PhabricatorService().request_reviews(
+            host=self.config['host'],
+            token=self.config['token'],
+            repo_name=None
+        )
+        self.assertEqual(response[0]._format_oneline(1, 1),
+                         self.config['msg1'])
+
+    @mock.patch('phabricator.Phabricator.update_interfaces',
+                side_effect=test_mock.mock_phabricator_update_interfaces)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.get_reviews',
+                side_effect=test_mock.mock_phabricator_get_reviews)
+    @mock.patch(
+        'reviewrot.phabricatorstack.PhabricatorService.differential_query',
+        side_effect=test_mock.mock_phabricator_differential_query)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.author_data',
+                side_effect=test_mock.mock_phabricator_author_data)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.time_from_epoch',
+                side_effect=test_mock.mock_phabricator_time_from_epoch)
+    def test_request_reviews_with_repos(
+            self,
+            mock_phabricator_update_interfaces,
+            mock_phabricator_get_reviews,
+            mock_phabricator_differential_query_no_repos,
+            mock_phabricator_author_data,
+            mock_phabricator_time_from_epoch):
+        response = PhabricatorService().request_reviews(
+            host=self.config['host'],
+            token=self.config['token'],
+            repo_name=["dummy_user"]
+        )
+        self.assertEqual(response[0]._format_oneline(1, 1),
+                         self.config['msg1'])
+
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.user_query_ids',
+                side_effect=test_mock.mock_phabricator_user_query_ids)
+    def test_author_data_empty(
+            self,
+            mock_phabricator_user_query_ids):
+        phab = Phabricator(host='dummmy.com', token='dummy.token')
+        response, raw_response = PhabricatorService().author_data(
+            author_phid="1234",
+            raw_response=[],
+            phab=phab)
+        self.assertTrue(response['userName'] == 'dummy_user')
+
+    def test_author_data_full(
+            self):
+        phab = Phabricator(host='dummmy.com', token='dummy.token')
+        response, raw_response = PhabricatorService().author_data(
+            author_phid="PHID-USER-test",
+            raw_response=test_mock.mock_phabricator_raw_response(),
+            phab=phab)
+        print(response)
+        self.assertTrue(True, False)
+
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.get_comments',
+                side_effect=test_mock.mock_phabricator_get_comments)
+    @mock.patch(
+        'reviewrot.phabricatorstack.PhabricatorService.get_last_comment',
+        side_effect=test_mock.mock_phabricator_get_last_comment)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.author_data',
+                side_effect=test_mock.mock_phabricator_author_data)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.time_from_epoch',
+                side_effect=test_mock.mock_phabricator_time_from_epoch)
+    def test_get_reviews_no_raw(self, mock_get_comments,
+                         mock_phabricator_get_last_comment,
+                         mock_phabricator_author_data,
+                         mock_phabricator_time_from_epoch):
+        reviews = test_mock.mock_phabricator_differential_query(
+            None, None, None)
+        phab = Phabricator(host='dummmy.com', token='dummy.token')
+        response = PhabricatorService().get_reviews(phab, reviews,
+                                                    host="www.google.com",
+                                                    raw_response=[])
+        self.assertEqual(response[0]._format_oneline(1, 1),
+                         self.config['msg2'])
+
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.get_comments',
+                side_effect=test_mock.mock_phabricator_get_comments_)
+    @mock.patch(
+        'reviewrot.phabricatorstack.PhabricatorService.get_last_comment',
+        side_effect=test_mock.mock_phabricator_get_last_comment)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.author_data',
+                side_effect=test_mock.mock_phabricator_author_data)
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.time_from_epoch',
+                side_effect=test_mock.mock_phabricator_time_from_epoch)
+    def test_get_reviews_last_comment(self, mock_phabricator_get_comments_,
+                                      mock_phabricator_get_last_comment,
+                                      mock_phabricator_author_data,
+                                      mock_datetime_fromtimestamp):
+        reviews = test_mock.mock_phabricator_differential_query(
+            None, None, None)
+        phab = Phabricator(host='dummmy.com', token='dummy.token')
+        response = PhabricatorService().get_reviews(
+            phab,
+            reviews,
+            host="www.google.com",
+            show_last_comment=True,
+            raw_response=[])
+        self.assertEqual(response[0]._format_oneline(1, 1),
+                         self.config['msg3'])
+
+    @mock.patch('reviewrot.phabricatorstack.PhabricatorService.author_data',
+                side_effect=test_mock.mock_phabricator_author_data)
+    def test_get_last_comment(self, mock_phabricator_author_data):
+        phab = Phabricator(host='dummy.com', token='dummy.token')
+        comments = test_mock.mock_phabricator_get_comments(1201, phab)
+        response = PhabricatorService().get_last_comment(comments, phab, raw_response=[])
+        createdAt = datetime.datetime.fromtimestamp(float(1551763640))
+        res = LastComment(author='dummy_user',
+                          body='This is some content',
+                          created_at=createdAt)
+        self.assertEqual(response, res)
 
 
 class GithubTest(TestCase):

--- a/test/test_mock.py
+++ b/test/test_mock.py
@@ -5,6 +5,9 @@ import gitlab
 from github.GithubException import UnknownObjectException
 from gitlab.exceptions import GitlabGetError
 from collections import namedtuple
+import datetime
+from reviewrot.basereview import LastComment
+from reviewrot.phabricatorstack import PhabricatorReview
 
 
 with open(join(dirname(__file__), "test_githubtest.yaml"), "r") as f:
@@ -129,3 +132,241 @@ class FakeProjectMergeRequestNote:
         self.author = {"username": author}
         self.created_at = created_at
         self.body = body
+
+
+# Phabricator
+
+def mock_phabricator_differential_query(status, responsibleUsers, phab):
+    class MockResponse:
+        def __init__(self, json_data, status):
+            self.json_data = json_data
+            self.status = status
+
+        def json(self):
+            return self.json_data
+
+        def next(self):
+            return
+
+        def getresponse(self):
+            return self.json_data
+
+    res = [
+        {
+            'reviewers': [
+                'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+                'PHID-USER-xxxxxxxxxxxxxxxxxxxx'
+            ],
+            'lineCount': '2',
+            'repositoryPHID': None,
+            'id': 1706,
+            'authorPHID': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+            'title': 'Title 1',
+            'activeDiffPHID': 'PHID-DIFF-xxxxxxxxxxxxxxxxxxxx',
+            'branch': 'new_input_data',
+            'dateModified': '1553524722',
+            'status': '2',
+            'testPlan': '',
+            'commits': [],
+            'dateCreated': '1553065630',
+            'hashes': [],
+            'properties': [],
+            'diffs': [
+                '3605',
+                '3599'
+            ],
+            'phid': 'PHID-DREV-xxxxxxxxxxxxxxxxxxxx',
+            'uri': 'dummy.url',
+            'css': [],
+            'summary': 'This is a summary.',
+            'statusName': 'Accepted'
+        },
+    ]
+    return res
+
+
+def mock_phabricator_get_comments(id, phab):
+    return [
+                {
+                    'action': 'comment',
+                    'authorPHID': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+                    'revisionID': id,
+                    'content': 'This is some content',
+                    'dateCreated': '1551763640'
+                }
+        ]
+
+def mock_phabricator_get_comments_(id, phab):
+    return [
+                {
+                    'action': 'comment',
+                    'authorPHID': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+                    'revisionID': id,
+                    'content': 'This is some content',
+                    'dateCreated': '1551763640'
+                },
+                {
+                    'action': 'comment',
+                    'authorPHID': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+                    'revisionID': id,
+                    'content': 'This is some content',
+                    'dateCreated': '1551763640'
+                },
+                {
+                    'action': 'comment',
+                    'authorPHID': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+                    'revisionID': id,
+                    'content': 'This is some content',
+                    'dateCreated': '1551763640'
+                }
+        ]
+
+
+def mock_phabricator_get_reviews(phab, reviews, host, state_,
+                                 value, duration, show_last_comment,
+                                 raw_response):
+    res = []
+    date_created = datetime.datetime.strptime('16Sep2012', '%d%b%Y')
+    date_modified = datetime.datetime.strptime('16Sep2012', '%d%b%Y')
+    last_comment = LastComment(author='user_name',
+                               body='content',
+                               created_at=date_modified)
+    temp = PhabricatorReview(user='user_name',
+                             title='Title 1',
+                             url='dummy.url',
+                             time=date_created,
+                             updated_time=date_modified,
+                             comments=2,
+                             image='https://authorImage.com',
+                             last_comment=last_comment,
+                             project_name='Phabricator',
+                             project_url='www.google.com')
+    res.append(temp)
+    return res
+
+
+def mock_phabricator_get_last_comment(comments, phab, raw_response):
+    createdAt = datetime.datetime.strptime('16Sep2018', '%d%b%Y')
+    return LastComment(author='user_name',
+                       body='This is some content',
+                       created_at=createdAt)
+
+
+def mock_phabricator_user_query_ids(phids, phab):
+    return [
+        {
+            'userName': 'dummy_user',
+            'phid': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+            'realName': 'Dummy User',
+            'roles': [
+                'verified', 'approved', 'activated'
+            ],
+            'image': 'userimage.com',
+            'uri': 'userurl.com'
+        }
+    ]
+
+def mock_phabricator_author_data(author_phid, raw_response, phab):
+    user = {
+            'userName': 'dummy_user',
+            'phid': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+            'realName': 'Dummy User',
+            'roles': [
+                'verified', 'approved', 'activated'
+            ],
+            'image': 'userimage.com',
+            'uri': 'userurl.com'
+    }
+
+    raw_response = [
+        {
+            'userName': 'dummy_user',
+            'phid': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+            'realName': 'Dummy User',
+            'roles': [
+                'verified', 'approved', 'activated'
+            ],
+            'image': 'userimage.com',
+            'uri': 'userurl.com'
+        }
+    ]
+    return user, raw_response
+
+
+def mock_phabricator_user_serach(username, phab):
+    return {
+               'cursor': {
+                   'after': None,
+                   'limit': 100,
+                   'order': None,
+                   'before': None
+               },
+               'maps': {},
+               'data': [
+                   {
+                       'fields': {
+                            'username': 'dummyuser',
+                            'realName': 'Dummy User',
+                            'roles': [
+                                'verified',
+                                'approved',
+                                'activated'],
+                            'dateCreated': 1509530187,
+                            'policy': {
+                                'edit': 'no-one',
+                                'view': 'public'},
+                            'dateModified': 1509530333},
+                       'phid': 'PHID-USER-xxxxxxxxxxxxxxxxxxxx',
+                       'type': 'USER',
+                       'id': 86,
+                       'attachments': {}}],
+               'query': {
+                   'queryKey': None
+               }
+           }
+
+def mock_phabricator_raw_response():
+    return [
+        {
+            'userName': 'user1',
+            'phid': 'PHID-USER-xxxxxxxxxxxxxxxxxx',
+            'realName': 'user 1',
+            'roles': [
+                'verified',
+                'approved',
+                'activated'
+            ],
+            'image': 'user1.image',
+            'uri': 'user1.url'
+        },
+        {
+            'userName': 'user2',
+            'phid': 'PHID-USER-xxxxxxxxxxxxxxxxxx',
+            'realName': 'user 2',
+            'roles': [
+                'verified',
+                'approved',
+                'activated'
+            ],
+            'image': 'user2.image',
+            'uri': 'user2.url'
+        },
+        {
+            'userName': 'user3',
+            'phid': 'PHID-USER-test',
+            'realName': 'user 3',
+            'roles': [
+                'verified',
+                'approved',
+                'activated'
+            ],
+            'image': 'user3.image',
+            'uri': 'user3.url'
+        }
+    ]
+
+def mock_phabricator_update_interfaces():
+    return
+
+def mock_phabricator_time_from_epoch(epoch_time):
+    return datetime.datetime.strptime('16Sep2012', '%d%b%Y')

--- a/test/test_phabricatortest.yaml
+++ b/test/test_phabricatortest.yaml
@@ -1,0 +1,5 @@
+token: api-xxxxxxxxxxxxxxxxxxx
+host: testhost.com/api/
+msg1: "user_name filed 'Title 1' dummy.url 6 years 8 months 22 days 15 hours ago, 2 comments, last comment by user_name 6 years 8 months 22 days 15 hours ago"
+msg2: "dummy_user filed 'Title 1' dummy.url 6 years 8 months 22 days 15 hours ago, 1 comment, last comment by user_name 8 months 22 days 15 hours ago"
+msg3: "dummy_user filed 'Title 1' dummy.url 6 years 8 months 22 days 15 hours ago, 3 comments, last comment by user_name 8 months 22 days 15 hours ago"


### PR DESCRIPTION
Adds Phabricator support to review-rot. Look at examples/sampleinput.yaml to see how to specify users. If no repos are specified will search for all open reviews on the host (status = status-open). 

- @ralphbean 
- @pbortlov 