### PR TITLE
Add --ignore-wip as a parser argument  

### DIFF
--- a/reviewrot/__init__.py
+++ b/reviewrot/__init__.py
@@ -297,7 +297,9 @@ def parse_cli_args(args):
                         metavar="CHANNEL",
                         default=None,
                         help='send output to list of irc channels')
-
+    parser.add_argument('--ignore-wip',
+                        help='Omit WIP PRs/MRs from output',
+                        action='store_true')
     ssl_group = parser.add_argument_group('SSL')
     ssl_group.add_argument('-k', '--insecure',
                            default=False,


### PR DESCRIPTION
As pointed out by @lcarva, there is an issue when adding the --ignore-wip argument. I've just added it to the list of parser arguments. 

@pbortlov 