### PR TITLE
Add last_comment functionality to the "indented" report.

### DIFF
--- a/reviewrot/__init__.py
+++ b/reviewrot/__init__.py
@@ -151,7 +151,7 @@ def get_arguments(cli_arguments, config):
 
     format = parsed_arguments.get('format')
     show_last_comment = parsed_arguments.get('show_last_comment')
-    if (format in ['oneline', 'indented'] and
+    if (format in ['oneline'] and
             show_last_comment is not None):
         raise ValueError(
             '{} format doesn\'t support last comment functionality'.format(

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import time
+import textwrap
 
 from collections import OrderedDict, namedtuple
 
@@ -251,7 +252,7 @@ class BaseReview(object):
         """
         lookup = {
             'oneline': self._format_oneline(i, N),
-            'indented': self._format_indented(i, N),
+            'indented': self._format_indented(i, N, show_last_comment),
             'json': self._format_json(i, N, show_last_comment),
             'irc': self._format_irc(),
         }
@@ -286,7 +287,7 @@ class BaseReview(object):
 
         return string
 
-    def _format_indented(self, i, N):
+    def _format_indented(self, i, N, show_last_comment):
         """
         Format the result in indented style.
         Args:
@@ -294,6 +295,7 @@ class BaseReview(object):
                     in all the formatting methods
             N(int): Not used in this method, added to have same parameters
                     in all the formatting methods
+            show_last_comment (int): show last_comment text in output
         Return:
             formatted_string(str): Formatted string as per style
         """
@@ -313,6 +315,14 @@ class BaseReview(object):
                 self.format_duration(self.last_comment.created_at),
             )
 
+        if show_last_comment and self.last_comment:
+            # Wrap and indent lines to fit in a terminal, preserving newlines
+            lines = self.last_comment.body.split('\n')
+            lines = sum([textwrap.wrap(line) for line in lines], [])
+            comment = "\n".join(lines)
+            comment = textwrap.indent(comment, '\t\t')
+            string += "\n{}".format(comment)
+
         return string
 
     def _format_json(self, i, N, show_last_comment):
@@ -321,7 +331,7 @@ class BaseReview(object):
         Args:
             i(int): position in a list.
             N(int): length of the list.
-            show_last_comment (int): show last_comment text in output
+            show_last_comment (bool): show last_comment text in output
         Return:
             formatted_string(str): Formatted string as per style
         """


### PR DESCRIPTION
For use in a terminal, so you can see the last comment just like in the
json/web view.

Extra care is taken to ensure that the comment is wrapped to fit nicely in a
terminal, while preserving original newlines for readability.