### PR TITLE
Removing and updating tests to only support python 3.6, 3.7

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,5 +6,3 @@ omit=reviewrot/mailer.py
 [report]
 fail_under=60
 
-[html]
-directory=./coverage_report

--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ python setup.py develop
 ```
 
 ## [NEW] Tests
-You can use `tox` or `detox` to run the tests against multiple versions of python:
+You can use `tox` or `detox` to run the tests against Python 3.6 and 3.7:
 ```shell
 sudo dnf install python-detox
 detox
 ```
-Test outputs are stored under the [htmlcov-py27](htmlcov-py27) and [htmlcov-py36](htmlcov-py36) directory as 
-HTML files for Python versions 2.7 and 3.6 respectively. 
 
 ## Script:
 

--- a/reviewrot/basereview.py
+++ b/reviewrot/basereview.py
@@ -269,7 +269,6 @@ class BaseReview(object):
             comment = "\n".join(lines)
             comment = textwrap.indent(comment, '\t\t')
             string += "\n{}".format(comment)
-
         return string
 
     def _format_json(self, i, N, show_last_comment):

--- a/test/test_basereview.py
+++ b/test/test_basereview.py
@@ -314,8 +314,9 @@ class BaseReviewTest(TestCase):
         )
 
         # Validate function calls and response
-        self.assertEqual("mock_user filed 'mock_title' mock_url mock_duration ago, "
-                         "10 comments, last comment by mock_author mock_duration ago",
+        self.assertEqual("mock_user filed 'mock_title' mock_url"
+                         " mock_duration ago, 10 comments, "
+                         "last comment by mock_author mock_duration ago",
                          response)
 
     @patch(PATH + 'BaseReview.format_duration')
@@ -331,7 +332,7 @@ class BaseReviewTest(TestCase):
 
         # Call the function
         response = service._format_indented(
-            1, 1
+            1, 1, False
         )
 
         # Validate function calls and response
@@ -358,13 +359,15 @@ class BaseReviewTest(TestCase):
 
         # Call the function
         response = service._format_indented(
-            1, 1
+            1, 1, True
         )
 
         # Validate function calls and response
-        self.assertEqual("mock_user filed 'mock_title'\n\tmock_url\n\t"
-                         "mock_duration ago\n\t10 comments, last comment"
-                         " by mock_author mock_duration ago",
+        self.assertEqual("mock_user filed 'mock_title'"
+                         "\n\tmock_url\n\tmock_duration"
+                         " ago\n\t10 comments, last "
+                         "comment by mock_author mock_"
+                         "duration ago\n",
                          response)
 
     @patch(PATH + 'json')

--- a/test/test_command_line.py
+++ b/test/test_command_line.py
@@ -252,7 +252,8 @@ class CommandLineParserTest(TestCase):
     ):
 
         cli_args = argparse.Namespace(
-            format="oneline", show_last_comment=0, insecure=False, cacert=None
+            format="oneline", email='demo@gmail.com', show_last_comment=0,
+            insecure=False, cacert=None
         )
         with self.assertRaises(ValueError) as context:
             get_arguments(
@@ -264,7 +265,8 @@ class CommandLineParserTest(TestCase):
             self.assertTrue(msg in str(context.exception))
 
         cli_args = argparse.Namespace(
-            format="indented", show_last_comment=0, insecure=False, cacert=None
+            format="indented", email='demo@gmail.com',
+            show_last_comment=0, insecure=False, cacert=None
         )
         with self.assertRaises(ValueError) as context:
             get_arguments(
@@ -298,7 +300,8 @@ class CommandLineParserTest(TestCase):
         config = {
             "arguments": {
                 "format": "oneline",
-                "show_last_comment": 0
+                "show_last_comment": 0,
+                "email": "demo@gmail.com"
             }
         }
         with self.assertRaises(ValueError) as context:
@@ -313,7 +316,8 @@ class CommandLineParserTest(TestCase):
         config = {
             "arguments": {
                 "format": "indented",
-                "show_last_comment": 0
+                "show_last_comment": 0,
+                "email": "demo@gmail.com"
             }
         }
         with self.assertRaises(ValueError) as context:
@@ -322,7 +326,6 @@ class CommandLineParserTest(TestCase):
                 config=config
             )
             msg = "No format should be specified when selecting email output"
-
             self.assertTrue(msg in str(context.exception))
 
     def test_email_argument_in_config(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean, py27, py36, flake8
+envlist = clean, py36, py37, flake8
 
 [testenv]
 deps =
@@ -8,11 +8,11 @@ deps =
     pytest-cov
 sitepackages = False
 
-[testenv:py27]
-commands = pytest --cov --cov-append --cov-report html:htmlcov-py27
-
 [testenv:py36]
-commands = pytest --cov --cov-append --cov-report html:htmlcov-py36
+commands = pytest --cov --cov-append
+
+[testenv:py37]
+commands = pytest --cov --cov-append
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
After @ralphbean last merge, we've added a module that is python 3.3+ (textwrapper.indent). 

I believe this is a good excuse to stop supporting Python 2.7 & this merge attempts to fix the tests in the last merge along with removing support for 2.7. 

@Lukkra211 
@pbortlov 
@amarza-rh