### PR TITLE
Disable InsecureRequestWarning when insecure option is used

### DIFF
--- a/reviewrot/__init__.py
+++ b/reviewrot/__init__.py
@@ -4,6 +4,7 @@ import datetime
 import re
 import argparse
 import yaml
+import requests
 
 from os.path import exists, expanduser, expandvars
 from shutil import copyfile
@@ -140,6 +141,9 @@ def get_arguments(cli_arguments, config):
 
     if insecure:
         parsed_arguments['ssl_verify'] = False
+        requests.packages.urllib3.disable_warnings(
+            requests.packages.urllib3.exceptions.InsecureRequestWarning
+        )
     elif cacert:
         cacert = expanduser(expandvars(cacert))
         if not exists(cacert):

--- a/test/test_command_line.py
+++ b/test/test_command_line.py
@@ -35,7 +35,45 @@ class CommandLineParserTest(TestCase):
         with open(filename, "r") as f:
             cls.config = yaml.safe_load(f)
 
-    def test_args_from_config(self):
+    @mock.patch('reviewrot.exists', return_value=True)
+    def test_arg_cacert_from_config(self, mocked_exists):
+        """Ensure that cacert value from config file is used in
+        ssl_verify argument."""
+
+        cli_args = argparse.Namespace(
+            cacert=None,
+            insecure=False,
+        )
+
+        config_args = {
+            'arguments': {
+                'cacert': 'ca.crt',
+            },
+        }
+
+        arguments = get_arguments(cli_args, config_args)
+
+        self.assertEqual(arguments.get('ssl_verify'), 'ca.crt')
+        assert mocked_exists.called
+
+    @mock.patch('reviewrot.exists', return_value=True)
+    def test_arg_cacert_from_cli(self, mocked_exists):
+        """Ensure that cacert value from cli is used in ssl_verify
+        argument."""
+
+        cli_args = argparse.Namespace(
+            cacert='ca.crt',
+            insecure=False,
+        )
+
+        config_args = {}
+
+        arguments = get_arguments(cli_args, config_args)
+
+        self.assertEqual(arguments.get('ssl_verify'), 'ca.crt')
+        assert mocked_exists.called
+
+    def test_args_from_config_with_insecure(self):
         cli_args = argparse.Namespace(
             cacert=None,
             debug=False,


### PR DESCRIPTION
If insecure option is used, disable InsecureRequestWarning to make reading logging messages easier.

Parsing of insecure and cacert arguments is refactored. Tests to ensure that cacert value is used from cli or config file.

Failing tests are fixed to ensure that these changes don't break current tests.