### PR TITLE
Add ability to exclude Gerrit changes with no reviewers invited

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ### New: 
+- Exclude Gerrit changes with no reviewers invited
 - Refactoring all tests & Tox support 
 - Phabricator support (check examples/sampleinput_phabricator.yaml )
 - Possibility of omitting WIP pull requests/merge requests in output with *--ignore-wip* argument
@@ -148,3 +149,33 @@ Or in command line:
 review-rot --irc '#channel1' '#channel2'
 review-rot --irc \#channel1 \#channel2
 ```
+
+## Gerrit service
+
+### [NEW] Exclude changes with no reviewers invited:
+
+```
+git_services:
+  - type: gerrit
+    reviewers:
+      ensure: True
+```
+
+User accounts can be excluded from the reviewers list for the change, for example, to not count bot accounts as reviewers:
+
+```
+git_services:
+  - type: gerrit
+    reviewers:
+      id_key: email
+      excluded:
+        - the.bot@example.com
+```
+
+`id_key` is the `FieldName` to get the value to identify the reviewer. If not set defaults to `username`.
+
+`excluded` is a list of reviewers, identified by their `id_key` in the reviewers entity.
+
+If `reviewers` is not empty and `ensure` is not defined, it's implicitly True.
+
+ID values for `excluded` and `id_key` are the same as for [AccountInfo](https://gerrit-review.googlesource.com/Documentation/rest-api-accounts.html#account-info).

--- a/bin/review-rot
+++ b/bin/review-rot
@@ -78,6 +78,12 @@ def main():
         # get git service
         git_service = get_git_service(item['type'])
 
+        # Reviewers config for Gerrit service only
+        if type(git_service) == GerritService:
+            reviewers_config = item.get('reviewers')
+        else:
+            reviewers_config = None
+
         """
         check if username and/or repository information is given for
         specified git service
@@ -103,6 +109,7 @@ def main():
                             token=_get_token(item),
                             host=remove_trailing_slash_from_url(item.get('host')),
                             ssl_verify=arguments.get('ssl_verify'),
+                            reviewers_config=reviewers_config,
                         )
                     )
             else:

--- a/reviewrot/gerritstack.py
+++ b/reviewrot/gerritstack.py
@@ -40,7 +40,6 @@ class GerritService(BaseService):
             response (list): Returns list of list of pull requests for
                              specified repo name
         """
-        reviews = None
 
         # If the request for reviews is on a different host than the previous
         # request, update the URL and check if the new host exists.
@@ -52,15 +51,15 @@ class GerritService(BaseService):
         # checks if specified repo exists
         repo_exists = self.check_repo_exists(repo_name, ssl_verify)
 
-        if self.host_exists and repo_exists:
-            request_url = "{}/changes/?q=project:{}+status:open&" \
-                          "o=DETAILED_ACCOUNTS".format(self.url, repo_name)
-            log.debug('Looking for change requests for %s -> %s',
-                      self.url, repo_name)
-            review_response = self._call_api(url=request_url,
-                                             ssl_verify=ssl_verify)
-            reviews = self.format_response(review_response, age, show_last_comment)
-        return reviews
+        if not (self.host_exists and repo_exists):
+            return
+
+        request_url = ("{}/changes/?q=project:{}+status:open"
+                       "&o=DETAILED_ACCOUNTS").format(self.url, repo_name)
+        log.debug('Looking for change requests for %s -> %s', self.url, repo_name)
+        review_response = self._call_api(url=request_url, ssl_verify=ssl_verify)
+
+        return self.format_response(review_response, age, show_last_comment)
 
     def check_repo_exists(self, repo_name, ssl_verify):
         """

--- a/reviewrot/gerritstack.py
+++ b/reviewrot/gerritstack.py
@@ -76,7 +76,7 @@ class GerritService(BaseService):
         # checks if specified repo exists
         repo_exists = self.check_repo_exists(repo_name, ssl_verify)
 
-        if not (self.host_exists and repo_exists):
+        if not self.host_exists or not repo_exists:
             return
 
         request_url = ("{}/changes/?q=project:{}+status:open"

--- a/test/gerrit_tests/test_gerrit.py
+++ b/test/gerrit_tests/test_gerrit.py
@@ -295,9 +295,13 @@ class GerritTest(TestCase):
             'mock_repo',
             True
         )
+
+        changes_url = ('mock_host/changes/?q=project:mock_repo+status:open'
+                       '&o=DETAILED_ACCOUNTS'
+                       '&o=DETAILED_LABELS')
+
         mock_call_api.assert_called_with(
-            url='mock_host/changes/?q=project:'
-                'mock_repo+status:open&o=DETAILED_ACCOUNTS',
+            url=changes_url,
             ssl_verify=True
         )
         mock_format_response.assert_called_with(
@@ -340,8 +344,13 @@ class GerritTest(TestCase):
             'mock_repo',
             True
         )
+
+        changes_url = ('None/changes/?q=project:mock_repo+status:open'
+                       '&o=DETAILED_ACCOUNTS'
+                       '&o=DETAILED_LABELS')
+
         mock_call_api.assert_called_with(
-            url='None/changes/?q=project:mock_repo+status:open&o=DETAILED_ACCOUNTS',
+            url=changes_url,
             ssl_verify=True
         )
         mock_format_response.assert_called_with(
@@ -387,6 +396,145 @@ class GerritTest(TestCase):
         mock_call_api.assert_not_called()
         mock_format_response.assert_not_called()
         self.assertEqual(None, response)
+
+    @patch(PATH + 'GerritService.format_response')
+    @patch(PATH + 'GerritService._filter_invited', return_value=[])
+    @patch(PATH + 'GerritService._call_api')
+    @patch(PATH + 'GerritService.get_response', return_value=True)
+    @patch(PATH + 'requests')
+    def test_request_reviews_with_reviewers_config(self,
+                                                   mocked_requests,
+                                                   mocked_get_response,
+                                                   mocked_call_api,
+                                                   mocked_filter_invited,
+                                                   mocked_format_response):
+        """Ensure _filter_invited is called when reviewers config is
+        provided."""
+
+        mocked_call_api.return_value = [
+            {'id': 'change_id'},
+        ]
+
+        reviewers_config = {
+            'excluded': []
+        }
+
+        service = GerritService()
+
+        service.request_reviews(
+            'host', 'repo', reviewers_config=reviewers_config
+        )
+
+        assert mocked_requests.session.called
+        assert mocked_get_response.called
+        assert mocked_filter_invited.called
+        called_args, _ = mocked_filter_invited.call_args
+        assert [{'id': 'change_id'}] == called_args[0]
+        assert mocked_format_response.called
+
+    @patch(PATH + 'GerritService.format_response')
+    @patch(PATH + 'GerritService._filter_invited', return_value=[])
+    @patch(PATH + 'GerritService._call_api')
+    @patch(PATH + 'GerritService.get_response', return_value=True)
+    @patch(PATH + 'requests')
+    def test_request_reviews_without_reviewers_config(self,
+                                                      mocked_requests,
+                                                      mocked_get_response,
+                                                      mocked_call_api,
+                                                      mocked_filter_invited,
+                                                      mocked_format_response):
+        """Ensure _filter_invited is not called if there is no reviewers
+        config."""
+
+        mocked_call_api.return_value = [{'id': 'change_id'}]
+
+        reviewers_config = {}
+
+        service = GerritService()
+
+        service.request_reviews(
+            'host', 'repo', reviewers_config=reviewers_config
+        )
+
+        assert mocked_requests.session.called
+        assert mocked_get_response.called
+        assert not mocked_filter_invited.called
+        assert mocked_format_response.called
+
+    @patch(PATH + 'requests')
+    def test_filter_invited_no_excluded(self, mocked_requests):
+        """Ensure changes without reviewers are filtered out from the
+        change list."""
+
+        reviewers_config = {'ensure': True}
+
+        changes = [
+            {
+                'id': 'change1',
+                'project': 'the-project-1',
+                'subject': 'the subject 1',
+                'reviewers': {'REVIEWER': []},
+            },
+            {
+                'id': 'change2',
+                'project': 'the-project-2',
+                'subject': 'the subject 2',
+                'reviewers': {'REVIEWER': [{'email': 'reviewer@example.com'}]},
+            }
+        ]
+
+        service = GerritService()
+
+        assert mocked_requests.session.called
+        filtered_changes = service._filter_invited(changes, **reviewers_config)
+
+        assert len(filtered_changes) == 1
+        assert filtered_changes[0]['id'] == 'change2'
+
+    @patch(PATH + 'requests')
+    def test_filter_invited_excluded(self, mocked_requests):
+        """Ensure changes with only excluded reviewers are filtered out
+        from the change list."""
+
+        reviewers_config = {
+            'id_key': 'email',
+            'excluded': [
+                'bot@example.com',
+            ],
+        }
+
+        changes = [
+            {
+                'id': 'change1',
+                'project': 'the-project-1',
+                'subject': 'the subject 1',
+                'reviewers': {'REVIEWER': []},
+            },
+            {
+                'id': 'change2',
+                'project': 'the-project-2',
+                'subject': 'the subject 2',
+                'reviewers': {'REVIEWER': [{'email': 'bot@example.com'}]},
+            },
+            {
+                'id': 'change3',
+                'project': 'the-project-3',
+                'subject': 'the subject 3',
+                'reviewers': {
+                    'REVIEWER': [
+                        {'email': 'reviewer@example.com'},
+                        {'email': 'bot@example.com'}
+                    ]
+                },
+            }
+        ]
+
+        service = GerritService()
+
+        assert mocked_requests.session.called
+        filtered_changes = service._filter_invited(changes, **reviewers_config)
+        assert len(filtered_changes) == 1
+        assert filtered_changes[0]['id'] == 'change3'
 
     def test_get_comments_count(self):
         """

--- a/test/gerrit_tests/test_gerrit.py
+++ b/test/gerrit_tests/test_gerrit.py
@@ -421,16 +421,17 @@ class GerritTest(TestCase):
 
         service = GerritService()
 
+        mocked_requests.session.assert_called()
+
         service.request_reviews(
             'host', 'repo', reviewers_config=reviewers_config
         )
 
-        assert mocked_requests.session.called
-        assert mocked_get_response.called
-        assert mocked_filter_invited.called
-        called_args, _ = mocked_filter_invited.call_args
-        assert [{'id': 'change_id'}] == called_args[0]
-        assert mocked_format_response.called
+        mocked_get_response.assert_called()
+        mocked_filter_invited.assert_called_once_with(
+            [{'id': 'change_id'}], excluded=[]
+        )
+        mocked_format_response.assert_called()
 
     @patch(PATH + 'GerritService.format_response')
     @patch(PATH + 'GerritService._filter_invited', return_value=[])
@@ -452,14 +453,15 @@ class GerritTest(TestCase):
 
         service = GerritService()
 
+        mocked_requests.session.assert_called()
+
         service.request_reviews(
             'host', 'repo', reviewers_config=reviewers_config
         )
 
-        assert mocked_requests.session.called
-        assert mocked_get_response.called
-        assert not mocked_filter_invited.called
-        assert mocked_format_response.called
+        mocked_get_response.assert_called()
+        mocked_filter_invited.assert_not_called()
+        mocked_format_response.assert_called()
 
     @patch(PATH + 'requests')
     def test_filter_invited_no_excluded(self, mocked_requests):
@@ -485,11 +487,15 @@ class GerritTest(TestCase):
 
         service = GerritService()
 
-        assert mocked_requests.session.called
+        mocked_requests.session.assert_called()
+
         filtered_changes = service._filter_invited(changes, **reviewers_config)
 
-        assert len(filtered_changes) == 1
-        assert filtered_changes[0]['id'] == 'change2'
+        changes_count = len(filtered_changes)
+        self.assertEqual(changes_count, 1)
+
+        change_id = filtered_changes[0]['id']
+        self.assertEqual(change_id, 'change2')
 
     @patch(PATH + 'requests')
     def test_filter_invited_excluded(self, mocked_requests):
@@ -531,10 +537,15 @@ class GerritTest(TestCase):
 
         service = GerritService()
 
-        assert mocked_requests.session.called
+        mocked_requests.session.assert_called()
+
         filtered_changes = service._filter_invited(changes, **reviewers_config)
-        assert len(filtered_changes) == 1
-        assert filtered_changes[0]['id'] == 'change3'
+
+        changes_count = len(filtered_changes)
+        self.assertEqual(changes_count, 1)
+
+        change_id = filtered_changes[0]['id']
+        self.assertEqual(change_id, 'change3')
 
     def test_get_comments_count(self):
         """


### PR DESCRIPTION
It's common to have for some time Gerrit changes without reviewers invited. For example, the CI failed and the change needs a new PS to be fixed. In these cases, these changes shouldn't be counted as reviews.
This change adds ability to skip changes with no reviewers and also allows to exclude users from the reviewers in the change. This can be used to not count as reviewers bot accounts used, for example, by the CI.