### PR TITLE
Upgrade Dockerfile to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ USER root
 
 RUN yum install -y epel-release && yum update -y && \
     yum install -y git gcc python-devel \
-    python-setuptools python-pip libyaml-devel && \
+    python3-setuptools python3-pip libyaml-devel && \
     yum clean all
 
 # copy workdir for installation of review-rot
@@ -17,7 +17,7 @@ WORKDIR /reviewrot
 ADD . /reviewrot
 
 # install review-rot
-RUN pip install --upgrade pip setuptools && python setup.py install
+RUN pip3 install --upgrade pip setuptools && python3 setup.py install
 
 # create direcory for the run of review-rot,
 # set privileges and env variable


### PR DESCRIPTION
The container can't be built with python2 anymore, so we might as well switch to the python3 packages fully.

The error appears at docker build:

```bash
docker build -t review-rot:latest .
...
Step 10/12 : RUN pip install --upgrade pip setuptools && python setup.py install
 ---> Running in 80f8e409519f
Collecting pip
  Downloading https://files.pythonhosted.org/packages/54/eb/4a3642e971f404d69d4f6fa3885559d67562801b99d7592487f1ecc4e017/pip-20.3.3-py2.py3-none-any.whl (1.5MB)
Collecting setuptools
  Downloading https://files.pythonhosted.org/packages/82/2f/ef7afd98530d07c89deffec833b4b1a91a27a5db6d9f1a216599f5f0316e/setuptools-51.1.2.tar.gz (2.1MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "setuptools/__init__.py", line 16, in <module>
        import setuptools.version
      File "setuptools/version.py", line 1, in <module>
        import pkg_resources
      File "pkg_resources/__init__.py", line 1365
        raise SyntaxError(e) from e
                                ^
    SyntaxError: invalid syntax
```


After this fix docker-build works:

```bash
docker build -t review-rot:latest .
...
Successfully tagged review-rot:latest

docker run --rm -it review-rot:latest bash
review-rot --help
...
```