### PR TITLE
Use Python 3.9 in container image, drop Python 3.6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN microdnf update \
         gcc \
         git \
         libyaml-devel \
-        python3-devel \
-        python3-pip \
-        python3-setuptools \
+        python39-devel \
+        python39-pip \
+        python39-setuptools \
     && microdnf clean all
 
 # copy workdir for installation of review-rot

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python setup.py develop
 ```
 
 ## [NEW] Tests
-You can use `tox` or `detox` to run the tests against Python 3.6 and 3.7:
+You can use `tox` or `detox` to run the tests against Python 3.7+:
 ```shell
 sudo dnf install python-detox
 detox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean, py3{6,7,8,9,10}, flake8, black
+envlist = clean, py3{7,8,9,10}, flake8, black
 basepython = /usr/bin/python3
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Python package python-gitlab supports only Python 3.7+.

Builds the container image with Python 3.9.